### PR TITLE
인풋 공동 컴포넌트 리액트 훅 폼 연동 작업

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import Input from '@/shared/ui/Input';
+
+const LoginPage = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, errors },
+  } = useForm();
+
+  return (
+    <form
+      className='flex flex-col'
+      noValidate
+      onSubmit={handleSubmit(data => {
+        alert(JSON.stringify(data));
+      })}
+    >
+      <label htmlFor='email'>이메일</label>
+      <Input
+        id='email'
+        type='email'
+        placeholder='text@email.com'
+        {...register('email', {
+          required: '이메일은 필수 입력입니다.',
+          pattern: {
+            value: /\S+@\S+\.\S+/,
+            message: '이메일 형식이 아닙니다.',
+          },
+        })}
+      />
+      {errors.email && <p>{errors.email.message?.toString()}</p>}
+      <label htmlFor='password'>비밀번호</label>
+      <Input
+        id='password'
+        type='password'
+        placeholder='**********'
+        {...register('password', {
+          required: '비밀번호는 필수 입력입니다.',
+          minLength: {
+            value: 8,
+            message: '비밀번호는 8자 이상입니다.',
+          },
+        })}
+      />
+      {errors.password && <p>{errors.password.message?.toString()}</p>}
+      <button type='submit' disabled={isSubmitting}>
+        로그인
+      </button>
+    </form>
+  );
+};
+
+export default LoginPage;

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -6,6 +6,8 @@
  * @returns 사이즈에 맞는 인풋을 반환합니다.
  */
 
+import { forwardRef } from 'react';
+
 interface InputComponentProps {
   className?: string;
   type?: string;
@@ -14,25 +16,15 @@ interface InputComponentProps {
   placeholder?: string;
   width?: string;
   height?: string;
+  id?: string;
 }
 
-const Input = ({
-  type,
-  value,
-  onChange,
-  placeholder,
-  width = 'w-80',
-  height,
-}: InputComponentProps) => {
-  return (
-    <input
-      className={`${width} ${height} flex items-start gap-2 self-stretch rounded-md border bg-white px-4 py-5`}
-      type={type}
-      value={value}
-      onChange={onChange}
-      placeholder={placeholder}
-    />
-  );
-};
+const Input = forwardRef<HTMLInputElement, InputComponentProps>(
+  ({ className, width = 'w-80', height = '', ...rest }, ref) => {
+    const inputClassName = `${width} ${height} ${className || ''} flex items-start gap-2 self-stretch rounded-md border bg-white px-4 py-5`;
+
+    return <input {...rest} ref={ref} className={inputClassName} />;
+  },
+);
 
 export default Input;

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -4,6 +4,8 @@
  * @param {string} height
  * 테일윈드 규칙으로 작성해주시면 됩니다. 필수는 아닙니다.
  * @returns 사이즈에 맞는 인풋을 반환합니다.
+ *
+ * forwardRef를 사용하여 리액트 훅 폼의 register를 props로 받아 사용할 수 있도록 하였습니다.
  */
 
 import { forwardRef } from 'react';


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 인풋 공동 컴포넌트 forwardRef 추가

## 📣리뷰어가 꼭 알아야 하는 사항

- forwardRef를 사용하여 리액트 훅 폼의 register를 props로 받아 사용할 수 있도록 하였습니다.

## ❗관련이슈

- closed: #

## 🖼️스크린샷(선택)
