### PR TITLE
[일반회원 페이지] 프로필 상세 페이지 스타일 수정 및 수정사항 파악

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
       'mblogthumb-phinf.pstatic.net',
       'rimage.gnst.jp',
       'static.wtable.co.kr',
+      'news.nateimg.co.kr',
     ],
   },
 };

--- a/src/shared/NotificationModal/NotificationItem.tsx
+++ b/src/shared/NotificationModal/NotificationItem.tsx
@@ -24,9 +24,9 @@ export const AcceptedItem = ({
     <button
       type='button'
       onClick={() => onClick(id)}
-      className='w-238 rounded-5 rounded-5 flex flex-col items-start justify-start gap-4 border border-solid border-[white] bg-white px-12 py-16 text-start md:w-full'
+      className='w-[238 flex flex-col items-start justify-start gap-[4px] rounded-[5px] border border-solid border-[white] bg-white px-[12px] py-[16px] text-start'
     >
-      <div className='rounded-70 h-5 w-5 bg-[#0080ff]'></div>
+      <div className='h-[5px] w-[5px] rounded-[70px] bg-[#0080ff]'></div>
       <p className='text-sm font-normal text-black'>
         {name}({duration}) 공고 지원이{' '}
         <span className='text-[#0080ff]'>승인</span>되었어요.

--- a/src/shared/NotificationModal/NotificationModal.tsx
+++ b/src/shared/NotificationModal/NotificationModal.tsx
@@ -23,14 +23,10 @@ const NotifiactionModal = ({
   };
 
   return (
-    <div className='z-1000 right-350 rounded-10 relative top-12 w-[368px] overflow-y-auto border border-solid border-[#cbc9cf] bg-[#ffebe7] px-20 py-0 pb-24 shadow-md md:fixed md:inset-0 md:w-full md:rounded-none md:border-0 md:shadow-none'>
+    <div className='z-1000 right-350 rounded-10 relative top-12 w-[368px] overflow-y-auto border border-solid border-[#cbc9cf] bg-[#ffebe7] px-20 py-0 pb-24 shadow-md'>
       <div className='bg-#ffebe7] sticky top-0 flex justify-between pb-16 pt-24'>
         <h1 className='text-lg font-bold'>{`알림 ${items.length}개`}</h1>
-        <button
-          type='button'
-          onClick={handleClose}
-          className='md:top-26 hidden md:right-20 md:block'
-        >
+        <button type='button' onClick={handleClose}>
           <Image src={'/close.svg'} alt='닫기 아이콘' width={24} height={24} />
         </button>
       </div>

--- a/src/shared/NotificationModal/NotificationModal.tsx
+++ b/src/shared/NotificationModal/NotificationModal.tsx
@@ -23,16 +23,16 @@ const NotifiactionModal = ({
   };
 
   return (
-    <div className='z-1000 right-350 rounded-10 relative top-12 w-[368px] overflow-y-auto border border-solid border-[#cbc9cf] bg-[#ffebe7] px-20 py-0 pb-24 shadow-md'>
-      <div className='bg-#ffebe7] sticky top-0 flex justify-between pb-16 pt-24'>
+    <div className='relative right-[350px] top-[12px] z-[1000] w-[368px] overflow-y-auto rounded-[10px] border border-solid border-[#cbc9cf] bg-[#ffebe7] px-[20px] py-0 pb-[24px] shadow-md'>
+      <div className='sticky top-0 flex justify-between bg-[#ffebe7] pb-[16px] pt-[24px]'>
         <h1 className='text-lg font-bold'>{`알림 ${items.length}개`}</h1>
         <button type='button' onClick={handleClose}>
           <Image src={'/close.svg'} alt='닫기 아이콘' width={24} height={24} />
         </button>
       </div>
-      <div className='flex flex-col gap-8'>
+      <div className='flex flex-col gap-[8px]'>
         {items.length === 0 && (
-          <div className='h-300 flex flex-col items-center justify-center'>
+          <div className='flex h-[300px] flex-col items-center justify-center'>
             <span>알림이 없습니다!</span>
           </div>
         )}

--- a/src/shared/api/RequestMethod.ts
+++ b/src/shared/api/RequestMethod.ts
@@ -41,8 +41,8 @@ export const putMethod = async <T>(
 ): Promise<T> => {
   const response = await AxiosInstance.put<ResponseInterface<T>>(
     url,
-    config as InternalAxiosRequestConfig,
     data,
+    config as InternalAxiosRequestConfig,
   );
   return response.data;
 };

--- a/src/shared/ui/Loader.tsx
+++ b/src/shared/ui/Loader.tsx
@@ -5,7 +5,7 @@ const Loader = () => {
     <CreatePortal id='loader'>
       <div className='fixed top-0 flex h-full w-full items-center justify-center bg-transparent'>
         <div className='relative inline-block h-[80px] w-[80px]'>
-          <div className='absolute left-[66px] h-1.5 w-1.5 animate-[scale_1.2s_linear_infinite] rounded-[50%] bg-[#949494]' />
+          <div className='absolute left-[66px] top-[37px] h-1.5 w-1.5 animate-[scale_1.2s_linear_infinite] rounded-[50%] bg-[#949494]' />
           <div className='absolute left-[62px] top-[22px] h-1.5 w-1.5 animate-[scale_1.2s_linear_infinite] rounded-[50%] bg-[#949494]' />
           <div className='absolute left-[52px] top-[11px] h-1.5 w-1.5 animate-[scale_1.2s_linear_infinite] rounded-[50%] bg-[#949494]' />
           <div className='absolute left-[37px] top-[7px] h-1.5 w-1.5 animate-[scale_1.2s_linear_infinite] rounded-[50%] bg-[#949494]' />

--- a/src/shared/ui/Pagination/ui/PaginationUi.tsx
+++ b/src/shared/ui/Pagination/ui/PaginationUi.tsx
@@ -31,7 +31,7 @@ const PaginationUi = ({
         >
           <ArrowUi isActive={isPrevious} direction='previous' />
         </Link>
-        <div className='flex flex-col items-center justify-center gap-0.5 text-sm font-normal  md:gap-1 md:text-xs md:font-normal'>
+        <div className='flex flex-col items-center justify-center gap-0.5 text-sm font-normal'>
           {showed.map(num => (
             <Link
               key={num}
@@ -39,7 +39,7 @@ const PaginationUi = ({
               className={`${page === num ? '' : 'pointer-events-none cursor-default'}`}
             >
               <span
-                className={`${page === num ? '' : 'bg-[#6b8a8c] text-white'} flex h-[40px] w-[40px] flex-col items-center justify-center rounded text-black md:h-[32px] md:w-[32px]`}
+                className={`${page === num ? '' : 'bg-[#6b8a8c] text-white'} flex h-[40px] w-[40px] flex-col items-center justify-center rounded text-black`}
               >
                 {num}
               </span>

--- a/src/shared/ui/Table/ui/TableBodyUi.tsx
+++ b/src/shared/ui/Table/ui/TableBodyUi.tsx
@@ -7,7 +7,7 @@ export const TableBody = ({ children }: { children: React.ReactNode }) => {
 
 export const TableBodyRow = ({ children }: { children: React.ReactNode }) => {
   return (
-    <tr className='border-b border-b-[#cbc9cf] text-base font-normal md:text-sm md:font-normal'>
+    <tr className='border-b border-b-[#cbc9cf] text-base font-normal'>
       {children}
     </tr>
   );
@@ -15,8 +15,8 @@ export const TableBodyRow = ({ children }: { children: React.ReactNode }) => {
 
 export const TableBodyCell = ({ children }: { children: React.ReactNode }) => {
   return (
-    <td className='px-3 py-5 align-middle md:px-2 md:py-[9px]'>
-      <div className='hidden-webkit flex flex-row items-center justify-start gap-3 md:gap-2'>
+    <td className='px-3 py-5 align-middle'>
+      <div className='hidden-webkit flex flex-row items-center justify-start gap-3'>
         {children}
       </div>
     </td>

--- a/src/shared/ui/Table/ui/TableContainerUi.tsx
+++ b/src/shared/ui/Table/ui/TableContainerUi.tsx
@@ -10,9 +10,7 @@ const TableContainerUi = ({
   return (
     <div className='relative w-full max-w-[964px] overflow-hidden rounded-[10px] border border-solid border-[#cbc9cf] bg-white'>
       <div className='overflow-x-auto'>
-        <table className='odd:w-[200px] even:w-[280px] md:odd:w-[170px] md:even:w-[230px]'>
-          {children}
-        </table>
+        <table className='w-full'>{children}</table>
       </div>
       {pagination}
     </div>

--- a/src/shared/ui/Table/ui/TableHeadUi.tsx
+++ b/src/shared/ui/Table/ui/TableHeadUi.tsx
@@ -1,7 +1,7 @@
 export const TableHeadRow = ({ children }: { children: React.ReactNode }) => {
   return (
     <thead>
-      <tr className='h-[50px] border-b border-b-[#cbc9cf] bg-[#ffebe7] text-left text-sm font-normal leading-[50px] md:h-[40px] md:text-xs md:font-normal md:leading-[40px]'>
+      <tr className='h-[50px] border-b border-b-[#cbc9cf] bg-[#ffebe7] text-left text-sm font-normal leading-[50px]'>
         {children}
       </tr>
     </thead>
@@ -9,9 +9,5 @@ export const TableHeadRow = ({ children }: { children: React.ReactNode }) => {
 };
 
 export const TableHeadCell = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <th className='pl-3 odd:w-[200px] even:w-[280px] md:pl-2 md:odd:w-[170px] md:even:w-[230px]'>
-      {children}
-    </th>
-  );
+  return <th className='pl-3'>{children}</th>;
 };

--- a/src/shared/ui/Title.tsx
+++ b/src/shared/ui/Title.tsx
@@ -30,7 +30,7 @@ const Title = ({
   children,
 }: TitleInterface) => {
   return (
-    <div className='relative m-0 mx-auto h-full max-w-[964px] px-0 py-[60px] md:px-[12px] md:py-[40px] lg:w-full lg:max-w-none lg:px-[32px] lg:py-[60px]'>
+    <div className='relative m-0 mx-auto h-full max-w-[964px] px-0 py-[60px]'>
       {subtitle && (
         <h2
           style={{ fontSize: subSize }}

--- a/src/widgets/Application/ui/ApplicationDataUi.tsx
+++ b/src/widgets/Application/ui/ApplicationDataUi.tsx
@@ -19,7 +19,7 @@ export const NoApplicationDataUi = () => {
         <NoProfileRegister
           text='아직 신청 내역이 없습니다.'
           button={
-            <div className='w-[346px] md:w-auto'>
+            <div className='w-[346px]'>
               <Button
                 text='공고 보러가기'
                 size='large'

--- a/src/widgets/Application/ui/NoRegisterUi.tsx
+++ b/src/widgets/Application/ui/NoRegisterUi.tsx
@@ -1,6 +1,6 @@
 const NoRegisterUi = () => {
   return (
-    <div className='relative mx-auto my-0 h-[460px] max-w-[964px] bg-white px-0 py-[60px] md:h-[330px] md:w-full md:px-[12px] md:py-[40px] lg:w-full lg:max-w-none lg:px-[32px] lg:py-[60px]' />
+    <div className='relative mx-auto my-0 h-[460px] max-w-[964px] bg-white px-0 py-[60px]' />
   );
 };
 

--- a/src/widgets/NoProfile/NoProfile.tsx
+++ b/src/widgets/NoProfile/NoProfile.tsx
@@ -15,7 +15,7 @@ export interface NoProfileInterface {
 
 const NoProfile = ({ isExist, profile }: NoProfileInterface) => {
   return (
-    <div className='min-h-[376px] md:min-h-[316px] lg:min-h-[434px]'>
+    <div className='min-h-[376px]'>
       <Title title='내 프로필' size={28} gap={32}>
         {!isExist && (
           <NoProfileRegister

--- a/src/widgets/NoProfile/NoProfileRegister.tsx
+++ b/src/widgets/NoProfile/NoProfileRegister.tsx
@@ -7,11 +7,9 @@ export interface NoProfileRegisterInterface {
 
 const NoProfileRegister = ({ text, button }: NoProfileRegisterInterface) => {
   return (
-    <div className='flex w-full flex-col items-center justify-center gap-[24px] rounded-[12px] border border-solid border-[#e5e4e7] pb-[60px] pt-[60px] md:gap-[16px]'>
-      <p className='text-base font-normal text-black md:text-sm md:font-normal'>
-        {text}
-      </p>
-      <div className='w-[346px] sm:w-auto'>{button}</div>
+    <div className='flex w-full flex-col items-center justify-center gap-[24px] rounded-[12px] border border-solid border-[#e5e4e7] pb-[60px] pt-[60px]'>
+      <p className='text-base font-normal text-black'>{text}</p>
+      <div className='w-[346px]'>{button}</div>
     </div>
   );
 };

--- a/src/widgets/ProfileContainer/ui/ProfileContainerUi.tsx
+++ b/src/widgets/ProfileContainer/ui/ProfileContainerUi.tsx
@@ -22,12 +22,12 @@ const ProfileContainerUi = ({
   bio,
 }: ProfileContainerUiInterface) => {
   return (
-    <div className='absolute right-0 top-[60px] w-[665px] rounded-xl bg-[#ffebe7] p-8 md:relative md:top-0 md:p-5 lg:relative lg:top-0 lg:w-full'>
+    <div className='absolute right-0 top-[60px] w-[665px] rounded-xl bg-[#ffebe7] p-8'>
       <div className='mb-3 flex flex-col gap-2'>
-        <h2 className='mb-3 flex flex-col gap-2 text-base font-bold text-[#3c6e71] md:text-sm md:font-bold'>
+        <h2 className='mb-3 flex flex-col gap-2 text-base font-bold text-[#3c6e71]'>
           이름
         </h2>
-        <h1 className='mb-3 flex flex-col gap-2 text-[28px] font-bold text-black md:text-2xl md:font-bold'>
+        <h1 className='mb-3 flex flex-col gap-2 text-[28px] font-bold text-black'>
           {name}
         </h1>
       </div>
@@ -36,7 +36,7 @@ const ProfileContainerUi = ({
           <Image src='/phone.png' alt='연락처 아이콘' width={20} height={20} />
           <span>{slicePhoneNumber(phone)}</span>
         </div>
-        <div className='mb-7 flex gap-1.5 text-base font-normal text-[#7d7986] md:text-sm md:font-normal'>
+        <div className='mb-7 flex gap-1.5 text-base font-normal text-[#7d7986]'>
           <Image
             src='/address.png'
             alt='선호 지역 아이콘'
@@ -46,10 +46,10 @@ const ProfileContainerUi = ({
           <span>선호 지역: {address}</span>
         </div>
       </div>
-      <div className='text-base font-normal md:text-sm md:font-normal'>
+      <div className='text-base font-normal'>
         <p>{bio}</p>
       </div>
-      <div className='absolute right-[32px] top-[32px] w-[169px] md:right-[20px] md:top-[20px] md:w-[108px]'>
+      <div className='absolute right-[32px] top-[32px] w-[169px]'>
         <EditButton name={name} phone={phone} address={address} bio={bio} />
       </div>
     </div>

--- a/src/widgets/RegisterModal/RegisterModal.tsx
+++ b/src/widgets/RegisterModal/RegisterModal.tsx
@@ -130,7 +130,7 @@ const RegisterModal = ({
       >
         <BackgroundModal onClick={onClickClose}>
           <Title title='내 프로필' gap={24}>
-            <div className='grid w-full grid-cols-3 grid-rows-1 pb-6 pt-1 md:grid-cols-2 md:grid-rows-2'>
+            <div className='grid w-full grid-cols-3 grid-rows-1 pb-6 pt-1'>
               <div className='w-full pr-5'>
                 <Input
                   type='input'
@@ -157,7 +157,7 @@ const RegisterModal = ({
                   }
                 />
               </div>
-              <div className='w-full lg:pr-5'>
+              <div className='w-full'>
                 <Select
                   type='search'
                   title='선호지역*'


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 쿠키 사용해 데이터 넘어오는 부분 확인
- 스타일 수정 (미디어 쿼리 부분 우선 삭제)

## 📣리뷰어가 꼭 알아야 하는 사항

- 우선 전체적인 스타일에서 미디어 쿼리 부분을 어떻게 사용해야 할지 잘 몰라 삭제하고 기본 스타일만 입혔습니다.
- 로그인 후 데이터 넘어오는거 확인했고, 프로필 정보 업데이트도 잘 되고, 신청 공고 목록도 잘 불러와지는 것 같습니다.

### 우선 수정해야 하는 사항
1. 프로필 편집에서 드롭다운에서 값 업데이트 해주는 부분
2. 페이지네이션 (값을 잘 지정해 주었는데도 제한때문에 옆으로 넘어가지 않고 있습니다. 이 부분 같이 해결해 주시면 감사하겠습니다ㅜㅜ)
3. 테이블에 상태값 잘 넘겨와 지는지 파악
4. 전체적인 스타일 수정 및 미디어 쿼리 스타일 지정

### 문제점 파악
1. 헤더가 모든 페이지에 적용되고 있어서 이 부분도 같이 얘기해보면 좋을 것 같습니다!
2. 헤더에 알림 모달이 아직 적용이 안된것 같습니다. 제 페이지 빨리 끝나면 이 부분 같이 작업하겠습니다!
3. 공고 페이지에서 신청하기 누르고 '/notice' 페이지로 이동해도 좋을 것 같습니다!

- 우선 기능적인 부분은 해결된 것 같습니다. 빨리 수정사항들 반영하도록 하겠습니다!

## ❗관련이슈

- closed: #79 

![Untitled](https://github.com/Party-Time-Job/Party-Time-Job/assets/122016324/fa1b5d3a-890e-4a2e-98cf-eb1226ee31ad)