### PR TITLE
추천 공고, 공고 리스트 페이지, 공고 상세 페이지, 사장님 공고 상세 페이지 스켈레톤 UI 적용

### DIFF
--- a/src/entities/Employer/EmployerNoticeDetail.tsx
+++ b/src/entities/Employer/EmployerNoticeDetail.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { getMethod } from '@/shared/api/RequestMethod.ts';
 import { Notice } from '../Post/types.ts';
 import EmployerDetailPost from '../Post/EmployerDetailPost.tsx';
+import DetailPostLoading from '../Post/DetailPostLoading.tsx';
+import NoticeDescription from '../Notice/NoticeDescription.tsx';
 
 const EmployerNoticeDetail = ({
   shopId,
@@ -27,27 +29,24 @@ const EmployerNoticeDetail = ({
 
   return (
     <section className='flex w-full items-center justify-center px-[12px] py-[40px] md:px-[32px] md:py-[60px]'>
-      <div className='flex w-full flex-col gap-4 lg:w-[964px]'>
-        <div className='flex flex-col gap-2'>
-          <span className='text-[14px] font-bold text-pt-green40 md:text-[16px] md:leading-[20px]'>
-            {detail?.item.shop.item.category}
-          </span>
-          <span className='text-[20px] font-bold md:text-[28px]'>
-            {detail?.item.shop.item.name}
-          </span>
-        </div>
-        <div className='flex flex-col gap-3'>
-          {detail ? <EmployerDetailPost notice={detail} /> : null}
-          <div className='flex flex-col items-start gap-2 rounded-xl bg-pt-gray20 p-[20px] lg:p-[32px]'>
-            <span className='text-[14px] font-bold md:text-[16px] md:leading-[20px]'>
-              공고 설명
+      {detail ? (
+        <div className='flex w-full flex-col gap-4 lg:w-[964px]'>
+          <div className='flex flex-col gap-2'>
+            <span className='text-[14px] font-bold text-pt-green40 md:text-[16px] md:leading-[20px]'>
+              {detail.item.shop.item.category}
             </span>
-            <p className='text-[14px] leading-[22px] md:text-[16px] md:leading-[26px]'>
-              {detail?.item.description}
-            </p>
+            <span className='text-[20px] font-bold md:text-[28px]'>
+              {detail.item.shop.item.name}
+            </span>
+          </div>
+          <div className='flex flex-col gap-3'>
+            <EmployerDetailPost notice={detail} />
+            <NoticeDescription detail={detail} />
           </div>
         </div>
-      </div>
+      ) : (
+        <DetailPostLoading />
+      )}
     </section>
   );
 };

--- a/src/entities/Notice/CustomNotice.tsx
+++ b/src/entities/Notice/CustomNotice.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import Post from '../Post/Post';
 import useCustomNotice from './hooks/useCustomNotice.ts';
+import CustomNoticeLoading from './CustomNoticeLoading.tsx';
 
 /**
  * @returns '/notice' 의 맞춤 공고 영역
@@ -17,16 +18,20 @@ const CustomNotice = () => {
           맞춤 공고
         </span>
         <div className='inline-flex w-full items-start gap-1 overflow-x-scroll scrollbar-hide md:gap-[14px]'>
-          {customNotice?.map(notice => {
-            return (
-              <Link
-                key={notice.item.id}
-                href={`/detail/${notice.item.shop.item.id}/${notice.item.id}`}
-              >
-                <Post key={notice.item.id} noticeItem={notice.item} />
-              </Link>
-            );
-          })}
+          {customNotice ? (
+            customNotice.map(notice => {
+              return (
+                <Link
+                  key={notice.item.id}
+                  href={`/detail/${notice.item.shop.item.id}/${notice.item.id}`}
+                >
+                  <Post key={notice.item.id} noticeItem={notice.item} />
+                </Link>
+              );
+            })
+          ) : (
+            <CustomNoticeLoading />
+          )}
         </div>
       </div>
     </section>

--- a/src/entities/Notice/CustomNoticeLoading.tsx
+++ b/src/entities/Notice/CustomNoticeLoading.tsx
@@ -1,0 +1,12 @@
+const CustomNoticeLoading = () => {
+  return (
+    <div className='flex gap-1 md:gap-[14px]'>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+    </div>
+  );
+};
+
+export default CustomNoticeLoading;

--- a/src/entities/Notice/NoticeDescription.tsx
+++ b/src/entities/Notice/NoticeDescription.tsx
@@ -1,0 +1,16 @@
+import { Notice } from '../Post/types.ts';
+
+const NoticeDescription = ({ detail }: { detail: Notice }) => {
+  return (
+    <div className='flex flex-col items-start gap-2 rounded-xl bg-pt-gray20 p-[20px] lg:p-[32px]'>
+      <span className='text-[14px] font-bold md:text-[16px] md:leading-[20px]'>
+        공고 설명
+      </span>
+      <p className='text-[14px] leading-[22px] md:text-[16px] md:leading-[26px]'>
+        {detail?.item.description}
+      </p>
+    </div>
+  );
+};
+
+export default NoticeDescription;

--- a/src/entities/Notice/NoticeDetail.tsx
+++ b/src/entities/Notice/NoticeDetail.tsx
@@ -30,36 +30,34 @@ const NoticeDetail = ({
 
   return (
     <section className='flex w-full items-center justify-center px-[12px] py-[40px] md:px-[32px] md:py-[60px]'>
-      <div className='flex w-full flex-col gap-4 lg:w-[964px]'>
-        <div className='flex flex-col gap-2'>
-          <span className='text-[14px] font-bold text-pt-green40 md:text-[16px] md:leading-[20px]'>
-            {detail?.item.shop.item.category}
-          </span>
-          <span className='text-[20px] font-bold md:text-[28px]'>
-            {detail?.item.shop.item.name}
-          </span>
+      {detail ? (
+        <div className='flex w-full flex-col gap-4 lg:w-[964px]'>
+          <div className='flex flex-col gap-2'>
+            <span className='text-[14px] font-bold text-pt-green40 md:text-[16px] md:leading-[20px]'>
+              {detail.item.shop.item.category}
+            </span>
+            <span className='text-[20px] font-bold md:text-[28px]'>
+              {detail.item.shop.item.name}
+            </span>
+          </div>
+          <div className='flex flex-col gap-3'>
+            <DetailPost
+              notice={detail}
+              userInfo={userInfo}
+              shopId={shopId}
+              noticeId={noticeId}
+              isApplied={isApplied}
+              token={token}
+              applicationId={applicationId}
+              isOutDatedNotice={isOutDatedNotice}
+              isClosed={isClosed}
+            />
+            <NoticeDescription detail={detail} />
+          </div>
         </div>
-        <div className='flex flex-col gap-3'>
-          {detail ? (
-            <>
-              <DetailPost
-                notice={detail}
-                userInfo={userInfo}
-                shopId={shopId}
-                noticeId={noticeId}
-                isApplied={isApplied}
-                token={token}
-                applicationId={applicationId}
-                isOutDatedNotice={isOutDatedNotice}
-                isClosed={isClosed}
-              />
-              <NoticeDescription detail={detail} />
-            </>
-          ) : (
-            <DetailPostLoading />
-          )}
-        </div>
-      </div>
+      ) : (
+        <DetailPostLoading />
+      )}
     </section>
   );
 };

--- a/src/entities/Notice/NoticeDetail.tsx
+++ b/src/entities/Notice/NoticeDetail.tsx
@@ -6,6 +6,7 @@ import useDetailNotice from './hooks/useDetailNotice.ts';
 import useApplication from './hooks/useApplication.ts';
 import useNoticeStatus from './hooks/useNoticeStatus.ts';
 import DetailPostLoading from '../Post/DetailPostLoading.tsx';
+import NoticeDescription from './NoticeDescription.tsx';
 
 /**
  * @param {Object} props - NoticeDetail 컴포넌트의 props
@@ -40,28 +41,23 @@ const NoticeDetail = ({
         </div>
         <div className='flex flex-col gap-3'>
           {detail ? (
-            <DetailPost
-              notice={detail}
-              userInfo={userInfo}
-              shopId={shopId}
-              noticeId={noticeId}
-              isApplied={isApplied}
-              token={token}
-              applicationId={applicationId}
-              isOutDatedNotice={isOutDatedNotice}
-              isClosed={isClosed}
-            />
+            <>
+              <DetailPost
+                notice={detail}
+                userInfo={userInfo}
+                shopId={shopId}
+                noticeId={noticeId}
+                isApplied={isApplied}
+                token={token}
+                applicationId={applicationId}
+                isOutDatedNotice={isOutDatedNotice}
+                isClosed={isClosed}
+              />
+              <NoticeDescription detail={detail} />
+            </>
           ) : (
             <DetailPostLoading />
           )}
-          <div className='flex flex-col items-start gap-2 rounded-xl bg-pt-gray20 p-[20px] lg:p-[32px]'>
-            <span className='text-[14px] font-bold md:text-[16px] md:leading-[20px]'>
-              공고 설명
-            </span>
-            <p className='text-[14px] leading-[22px] md:text-[16px] md:leading-[26px]'>
-              {detail?.item.description}
-            </p>
-          </div>
         </div>
       </div>
     </section>

--- a/src/entities/Notice/NoticeDetail.tsx
+++ b/src/entities/Notice/NoticeDetail.tsx
@@ -5,6 +5,7 @@ import { User } from '../Post/types.ts';
 import useDetailNotice from './hooks/useDetailNotice.ts';
 import useApplication from './hooks/useApplication.ts';
 import useNoticeStatus from './hooks/useNoticeStatus.ts';
+import DetailPostLoading from '../Post/DetailPostLoading.tsx';
 
 /**
  * @param {Object} props - NoticeDetail 컴포넌트의 props
@@ -50,7 +51,9 @@ const NoticeDetail = ({
               isOutDatedNotice={isOutDatedNotice}
               isClosed={isClosed}
             />
-          ) : null}
+          ) : (
+            <DetailPostLoading />
+          )}
           <div className='flex flex-col items-start gap-2 rounded-xl bg-pt-gray20 p-[20px] lg:p-[32px]'>
             <span className='text-[14px] font-bold md:text-[16px] md:leading-[20px]'>
               공고 설명

--- a/src/entities/Notice/NoticeList.tsx
+++ b/src/entities/Notice/NoticeList.tsx
@@ -7,6 +7,7 @@ import NoticeListHeader from './NoticeListHeader';
 import Pagination from './Pagination.tsx';
 import NoticeCategory from './NoticeCategory.tsx';
 import useNoticeListState from './hooks/useNoticeListState.ts';
+import NoticeListLoading from './NoticeListLoading.tsx';
 
 interface Props {
   category: string;
@@ -59,15 +60,19 @@ const NoticeList = ({ category, searchValue, recentNoticeList }: Props) => {
           ) : null}
         </div>
         <div className='grid grid-cols-2 grid-rows-3 gap-x-2 gap-y-4 md:gap-x-[14px] md:gap-y-[32px] lg:grid-cols-3 lg:grid-rows-2'>
-          {noticeItemList.items.map(notice => {
-            const shopId = notice.item.shop.item.id;
-            const noticeId = notice.item.id;
-            return (
-              <Link key={noticeId} href={`/detail/${shopId}/${noticeId}`}>
-                <Post key={noticeId} noticeItem={notice.item} />
-              </Link>
-            );
-          })}
+          {noticeItemList.items.length !== 0 ? (
+            noticeItemList.items.map(notice => {
+              const shopId = notice.item.shop.item.id;
+              const noticeId = notice.item.id;
+              return (
+                <Link key={noticeId} href={`/detail/${shopId}/${noticeId}`}>
+                  <Post key={noticeId} noticeItem={notice.item} />
+                </Link>
+              );
+            })
+          ) : (
+            <NoticeListLoading />
+          )}
         </div>
       </div>
       <Pagination

--- a/src/entities/Notice/NoticeListLoading.tsx
+++ b/src/entities/Notice/NoticeListLoading.tsx
@@ -1,0 +1,14 @@
+const NoticeListLoading = () => {
+  return (
+    <>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+      <div className='z-0 h-[262px] w-[173px] rounded-xl border-solid border-pt-gray20 bg-pt-gray20 md:h-[350px] md:w-[314px]'></div>
+    </>
+  );
+};
+
+export default NoticeListLoading;

--- a/src/entities/Post/DetailPostLoading.tsx
+++ b/src/entities/Post/DetailPostLoading.tsx
@@ -4,6 +4,7 @@ const DetailPostLoading = () => {
       <div className='mb-[8px] h-[20px] w-10 rounded-xl bg-pt-gray20'></div>
       <div className='mb-[16px] h-[30px] w-60 rounded-xl bg-pt-gray20 md:h-[42px]'></div>
       <div className='h-[360px] w-full rounded-xl border border-solid bg-pt-gray20 p-5 md:gap-5 md:p-[24px]'></div>
+      <div className='mt-3 h-[120px] w-full rounded-xl bg-pt-gray20'></div>
     </div>
   );
 };

--- a/src/entities/Post/DetailPostLoading.tsx
+++ b/src/entities/Post/DetailPostLoading.tsx
@@ -1,0 +1,11 @@
+const DetailPostLoading = () => {
+  return (
+    <div className='flex w-full flex-col items-start'>
+      <div className='mb-[8px] h-[20px] w-10 rounded-xl bg-pt-gray20'></div>
+      <div className='mb-[16px] h-[30px] w-60 rounded-xl bg-pt-gray20 md:h-[42px]'></div>
+      <div className='h-[360px] w-full rounded-xl border border-solid bg-pt-gray20 p-5 md:gap-5 md:p-[24px]'></div>
+    </div>
+  );
+};
+
+export default DetailPostLoading;

--- a/src/entities/Post/DetailPostLoading.tsx
+++ b/src/entities/Post/DetailPostLoading.tsx
@@ -1,6 +1,6 @@
 const DetailPostLoading = () => {
   return (
-    <div className='flex w-full flex-col items-start'>
+    <div className='flex w-full flex-col items-start lg:w-[964px]'>
       <div className='mb-[8px] h-[20px] w-10 rounded-xl bg-pt-gray20'></div>
       <div className='mb-[16px] h-[30px] w-60 rounded-xl bg-pt-gray20 md:h-[42px]'></div>
       <div className='h-[360px] w-full rounded-xl border border-solid bg-pt-gray20 p-5 md:gap-5 md:p-[24px]'></div>


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 공고 리스트 페이지, 공고 상세 페이지, 사장님 공고 상세 페이지 스켈레톤 UI 적용
- 사장님 공고 상세 페이지에 컴포넌트가 공통으로 들어가서 적용시켜봤습니다.

## 🖼️스크린샷(선택)
<img width="293" alt="image" src="https://github.com/Party-Time-Job/Party-Time-Job/assets/85405709/bed7e118-9c7a-48f5-9e15-6437d1ae14f7">
<img width="806" alt="image" src="https://github.com/Party-Time-Job/Party-Time-Job/assets/85405709/7ea22ef7-809f-4770-bc11-974f5fb5938f">
