### PR TITLE
[일반회원 페이지] revalidation 선언 및 연락처 자동 하이픈 추가

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,8 +7,6 @@ import NoRegisterUi from '@/widgets/Application/ui/NoRegisterUi';
 import NoProfile from '@/widgets/NoProfile/NoProfile';
 import getInformation from '@/widgets/api/getInformation';
 
-export const revalidate = 3600;
-
 const ProfilePage = async ({
   searchParams,
 }: {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,6 +7,8 @@ import NoRegisterUi from '@/widgets/Application/ui/NoRegisterUi';
 import NoProfile from '@/widgets/NoProfile/NoProfile';
 import getInformation from '@/widgets/api/getInformation';
 
+export const revalidate = 3600;
+
 const ProfilePage = async ({
   searchParams,
 }: {

--- a/src/widgets/Application/Application.tsx
+++ b/src/widgets/Application/Application.tsx
@@ -3,8 +3,6 @@ import getApplication from '@/widgets/api/getApplication';
 import ApplicationTable from '@/widgets/Application/ui/ApplicationTableUi';
 import { ProfileInterface } from '@/shared/ui/Table/type';
 
-export const revalidate = 3600;
-
 const Application = async ({ page }: { page: number }) => {
   let data;
   let total;

--- a/src/widgets/Application/Application.tsx
+++ b/src/widgets/Application/Application.tsx
@@ -3,6 +3,8 @@ import getApplication from '@/widgets/api/getApplication';
 import ApplicationTable from '@/widgets/Application/ui/ApplicationTableUi';
 import { ProfileInterface } from '@/shared/ui/Table/type';
 
+export const revalidate = 3600;
+
 const Application = async ({ page }: { page: number }) => {
   let data;
   let total;

--- a/src/widgets/RegisterModal/RegisterModal.tsx
+++ b/src/widgets/RegisterModal/RegisterModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+/* eslint-disable no-param-reassign */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable no-return-assign */
@@ -148,7 +149,28 @@ const RegisterModal = ({
                   defaultValue={defaultPhone || ''}
                   isRequired={false}
                   isValid={false}
-                  onChange={handleChange(setPhone)}
+                  onChange={event => {
+                    const reValue = event.target.value.replace(/\D/g, '');
+                    if (reValue === '') {
+                      event.target.value = '';
+                      return;
+                    }
+                    const autoInput = reValue.match(
+                      /^(\d{3})(\d{0,4})(\d{0,4})$/,
+                    );
+                    if (autoInput) {
+                      event.target.value = [
+                        autoInput[1],
+                        autoInput[2],
+                        autoInput[3],
+                      ]
+                        .filter(Boolean)
+                        .join('-');
+                    } else {
+                      event.target.value = reValue;
+                    }
+                    handleChange(setPhone)(event);
+                  }}
                   ref={(element: HTMLInputElement) =>
                     (inputRef.current[1] = element)
                   }

--- a/src/widgets/RegisterModal/RegisterModal.tsx
+++ b/src/widgets/RegisterModal/RegisterModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-/* eslint-disable no-param-reassign */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable no-return-assign */
@@ -149,28 +148,7 @@ const RegisterModal = ({
                   defaultValue={defaultPhone || ''}
                   isRequired={false}
                   isValid={false}
-                  onChange={event => {
-                    const reValue = event.target.value.replace(/\D/g, '');
-                    if (reValue === '') {
-                      event.target.value = '';
-                      return;
-                    }
-                    const autoInput = reValue.match(
-                      /^(\d{3})(\d{0,4})(\d{0,4})$/,
-                    );
-                    if (autoInput) {
-                      event.target.value = [
-                        autoInput[1],
-                        autoInput[2],
-                        autoInput[3],
-                      ]
-                        .filter(Boolean)
-                        .join('-');
-                    } else {
-                      event.target.value = reValue;
-                    }
-                    handleChange(setPhone)(event);
-                  }}
+                  onChange={handleChange(setPhone)}
                   ref={(element: HTMLInputElement) =>
                     (inputRef.current[1] = element)
                   }


### PR DESCRIPTION
## 🛠️주요 변경 사항

- revalidate 선언
- 연락처 onChange 수정

## 📣리뷰어가 꼭 알아야 하는 사항

- ravalidate 선언으로 캐시 유효화 설정했습니다. 그리고 연락처 입력 시 자동 하이픈(`-`) 입력 기능 추가했습니다.
- 제 페이지에서 편집 또는 등록 이후 로딩페이지를 보여주고 있는데, 이때 모달 -> 메인 페이지로 이동하여서 이 부분은 제가 만든 Loader 컴포넌트로 사용해도 좋을 것 같아서 우선 놔두고 필요하면 리팩토링 기간에 수정하도록 하겠습니다!!

## ❗관련이슈

- closed: #108 