### PR TITLE
맞춤 공고 자동 스크롤, 필터 주소 선택 4개이상 막기, 최근 본 공고 없을 때 UI

### DIFF
--- a/src/entities/Notice/CustomNotice.tsx
+++ b/src/entities/Notice/CustomNotice.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Post from '../Post/Post';
 import useCustomNotice from './hooks/useCustomNotice.ts';
 import CustomNoticeLoading from './CustomNoticeLoading.tsx';
+import useCustomNoticeScroll from './hooks/useCustomNoticeScroll.ts';
 import Text from '@/shared/ui/Text.tsx';
 
 /**
@@ -11,6 +12,7 @@ import Text from '@/shared/ui/Text.tsx';
  */
 const CustomNotice = () => {
   const customNotice = useCustomNotice();
+  const containerRef = useCustomNoticeScroll();
 
   return (
     <section className='flex w-full items-start justify-center border-b border-gray-500 bg-black px-[12px] py-[40px] md:px-[32px] md:py-[60px]'>
@@ -20,7 +22,10 @@ const CustomNotice = () => {
             맞춤공고
           </Text>
         </div>
-        <div className='inline-flex h-[400px] w-full items-center gap-1 overflow-x-scroll scrollbar-hide md:gap-[14px]'>
+        <div
+          ref={containerRef}
+          className='inline-flex w-full items-center gap-1 overflow-x-scroll scrollbar-hide md:gap-[14px]'
+        >
           {customNotice ? (
             customNotice.map(notice => {
               return (

--- a/src/entities/Notice/NoticeCategory.tsx
+++ b/src/entities/Notice/NoticeCategory.tsx
@@ -29,7 +29,7 @@ const NoticeCategory = ({ category, searchValue }: Props) => {
       <div className='flex gap-2'>
         <span className='flex h-10 w-28 items-center justify-center rounded-lg bg-test-blue text-lg font-bold text-black'>
           {searchValue}
-        </span>{' '}
+        </span>
         <span className='flex items-end font-bold text-test-blue'>
           검색 결과
         </span>

--- a/src/entities/Notice/NoticeListLoading.tsx
+++ b/src/entities/Notice/NoticeListLoading.tsx
@@ -7,8 +7,15 @@ const NoticeListLoading = ({
 }) => {
   if (category === 'search' || listCategory === 'filter') {
     return (
-      <div className='col-span-3 row-span-3 flex h-[520px] w-full items-center justify-center border-[2px] border-solid border-test-black md:h-[728px]'>
+      <div className='col-span-3 row-span-3 flex h-[520px] w-[354px] items-center justify-center border-[2px] border-solid border-test-black md:h-[728px] md:w-full'>
         앗... 검색 결과가 없습니다...
+      </div>
+    );
+  }
+  if (category === 'recent') {
+    return (
+      <div className='col-span-3 row-span-3 flex h-[520px] w-[354px] items-center justify-center border-[2px] border-solid border-test-black md:h-[728px] md:w-full'>
+        이번이 처음 본 공고에요!
       </div>
     );
   }

--- a/src/entities/Notice/Pagination.tsx
+++ b/src/entities/Notice/Pagination.tsx
@@ -20,7 +20,7 @@ const Pagination = ({
 }: Props) => {
   const defaultPageStyle =
     'flex h-[40px] w-[40px] items-center justify-center text-white p-[12px] cursor-pointer';
-  const activePageStyle = `${defaultPageStyle} rounded-[4px] bg-black border border-gray-500 font-blod`;
+  const activePageStyle = `${defaultPageStyle} rounded-[4px] bg-black border border-test-green font-blod`;
 
   const pageArray = setPagination(count, currentPageNumber);
 

--- a/src/entities/Notice/hooks/useCustomNoticeScroll.ts
+++ b/src/entities/Notice/hooks/useCustomNoticeScroll.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+const useCustomNoticeScroll = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const autoScroll = () => {
+      let toScroll = 328;
+      if (window.innerWidth < 768) {
+        toScroll = 176;
+      }
+
+      if (containerRef.current) {
+        const container = containerRef.current;
+        const scrollWidth = container.scrollWidth - container.clientWidth;
+        let newScrollLeft = container.scrollLeft + toScroll;
+
+        if (scrollWidth - container.scrollLeft < toScroll) {
+          container.scrollTop = container.scrollLeft;
+        }
+
+        if (scrollWidth - container.scrollLeft === 0) {
+          newScrollLeft = 0;
+        }
+
+        container.scrollTo({
+          left: newScrollLeft,
+          behavior: 'smooth',
+        });
+      }
+    };
+
+    const intervalId = setInterval(autoScroll, 2500);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return containerRef;
+};
+
+export default useCustomNoticeScroll;

--- a/src/features/Filter/UI/FilterUi.tsx
+++ b/src/features/Filter/UI/FilterUi.tsx
@@ -53,6 +53,9 @@ const Filter = ({
       removeAddress(addItem);
       return;
     }
+    if (selectedAddressList.length >= 3) {
+      return;
+    }
     setSelectedAddressList(prev => [...prev, addItem]);
   };
 
@@ -88,7 +91,7 @@ const Filter = ({
   };
 
   return (
-    <div className='absolute z-10 flex w-[390px] flex-col items-start gap-6 rounded-[10px] border border-solid border-[#E5E4E7] bg-test-black px-5 py-6 shadow-[0px_2px_8px_0px_rgba(120,116,134,0.25)] max-md:inset-0 max-md:w-full md:right-0 md:top-10'>
+    <div className='fixed z-10 flex w-[390px] flex-col items-start gap-5 rounded-[10px] border border-solid border-[#E5E4E7] bg-test-black px-5 py-6 shadow-[0px_2px_8px_0px_rgba(120,116,134,0.25)] max-md:inset-0 max-md:w-full md:absolute md:right-0 md:top-10'>
       <div className='flex items-center justify-between self-stretch'>
         <span className='text-xl font-bold leading-normal text-white '>
           상세필터


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 2.5초마다 맞춤 공고 자동 스크롤 
- 필터 주소 선택 4개이상 막기
- 최근 본 공고 없을 때 UI

## 📣리뷰어가 꼭 알아야 하는 사항
- 맞춤 공고가 약간 슴슴해보여서 자동 스크롤 추가해봤습니다
