### PR TITLE
공고 지원 승인, 거부 관련 로직 버그 픽스

### DIFF
--- a/src/features/AcceptModal/AcceptModal.tsx
+++ b/src/features/AcceptModal/AcceptModal.tsx
@@ -29,6 +29,7 @@ const AcceptModal = ({ handleToggle, category, acceptClick }: Props) => {
 
   const handleAcceptClick = () => {
     acceptClick();
+    handleToggle();
   };
 
   return (

--- a/src/features/RejectModal/RejectModal.tsx
+++ b/src/features/RejectModal/RejectModal.tsx
@@ -29,6 +29,7 @@ const RejectModal = ({ handleToggle, category, rejectClick }: Props) => {
 
   const handleRejectClick = () => {
     rejectClick();
+    handleToggle();
   };
 
   return (

--- a/src/page/NoticeDetailPage/utils/getUserToken.ts
+++ b/src/page/NoticeDetailPage/utils/getUserToken.ts
@@ -1,7 +1,9 @@
+import { getCookie } from 'cookies-next';
+
 const getUserToken = () => {
   if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('accessToken');
-    return token ? JSON.stringify(token) : '';
+    const token = getCookie('token');
+    return token || '';
   }
   return '';
 };

--- a/src/shared/ui/Table/Table.tsx
+++ b/src/shared/ui/Table/Table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import formatTime from '@/shared/utils/formatTime';
 import {
   ProfileTableInterface,
@@ -17,8 +17,6 @@ import {
   TableBodyStatus,
 } from '@/shared/ui/Table/ui/TableBodyUi';
 import getUserToken from '@/page/NoticeDetailPage/utils/getUserToken';
-import { getMethod } from '@/shared/api/RequestMethod';
-import { AllApply } from '@/entities/Post/types';
 import RejectModal from '@/features/RejectModal/RejectModal';
 import AcceptModal from '@/features/AcceptModal/AcceptModal';
 
@@ -84,82 +82,74 @@ export const StoreTable = ({
     secondValue: item.phone,
   }));
 
-  const [applicationId, setApplicationId] = useState<string>('');
   const token = getUserToken();
 
-  const [isToggle, setIsToggle] = useState(false);
   const [modalCategory, setModalCategory] = useState('');
 
+  const [selectedAplicationId, setSelectedAplicationId] = useState<
+    string | null
+  >(null);
   const [isAcceptToggle, setIsAcceptToggle] = useState(false);
+  const [isRejectToggle, setIsRejectToggle] = useState(false);
 
-  const handleToggle = () => {
-    setIsToggle(prev => !prev);
+  const handleRejectedStateToggle = () => {
+    setIsRejectToggle(prev => !prev);
   };
 
   const handleAcceptStateToggle = () => {
     setIsAcceptToggle(prev => !prev);
   };
 
-  const handleAcceptToggle = () => {
+  const handleAcceptToggle = (newApplicationId: string) => {
     setModalCategory('accept');
+    setSelectedAplicationId(newApplicationId);
     setIsAcceptToggle(prev => !prev);
   };
 
-  const handleRejectToggle = () => {
+  const handleRejectToggle = (newApplicationId: string) => {
     setModalCategory('reject');
-    setIsToggle(prev => !prev);
+    setSelectedAplicationId(newApplicationId);
+    setIsRejectToggle(prev => !prev);
   };
 
-  useEffect(() => {
-    const testUserApplyList = async () => {
-      const response = await getMethod<AllApply>(
-        `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications`,
-      );
-      const userApply = response.items;
-
-      if (userApply.length !== 0) {
-        setApplicationId(userApply[0].item.id);
-      }
-    };
-    testUserApplyList();
-  }, []);
-
-  const rejectedNotice = async () => {
+  const rejectedNotice = async (newApplicationId: string) => {
     await fetch(
-      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${newApplicationId}`,
       {
         method: 'PUT',
         headers: {
-          Authorization: `Bearer ${JSON.parse(token)}`,
+          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ status: 'rejected' }),
       },
     );
-    window.location.reload();
   };
 
   const rejectClick = () => {
-    rejectedNotice();
+    if (selectedAplicationId) {
+      rejectedNotice(selectedAplicationId);
+    }
   };
 
-  const acceptedNotice = async () => {
+  const acceptedNotice = async (newApplicationId: string) => {
     await fetch(
-      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${newApplicationId}`,
       {
         method: 'PUT',
         headers: {
-          Authorization: `Bearer ${JSON.parse(token)}`,
+          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ status: 'accepted' }),
       },
     );
-    window.location.reload();
   };
 
   const acceptClick = () => {
-    acceptedNotice();
+    if (selectedAplicationId) {
+      acceptedNotice(selectedAplicationId);
+    }
   };
 
   return (
@@ -183,13 +173,13 @@ export const StoreTable = ({
                   <div className='flex gap-2 text-xs'>
                     <button
                       className='rounded-lg border border-red-600 px-2 py-1 text-red-600'
-                      onClick={handleRejectToggle}
+                      onClick={() => handleRejectToggle(item.id)}
                     >
                       거절하기
                     </button>
                     <button
                       className='rounded-lg border border-blue-600 px-2 py-1 text-blue-600'
-                      onClick={handleAcceptToggle}
+                      onClick={() => handleAcceptToggle(item.id)}
                     >
                       승인하기
                     </button>
@@ -202,9 +192,9 @@ export const StoreTable = ({
           ))}
         </TableBody>
       </TableContainerUi>
-      {isToggle ? (
+      {isRejectToggle ? (
         <RejectModal
-          handleToggle={handleToggle}
+          handleToggle={handleRejectedStateToggle}
           category={modalCategory}
           rejectClick={rejectClick}
         />

--- a/src/shared/ui/Table/Table.tsx
+++ b/src/shared/ui/Table/Table.tsx
@@ -16,7 +16,6 @@ import {
   TableBodyRow,
   TableBodyStatus,
 } from '@/shared/ui/Table/ui/TableBodyUi';
-import getUserToken from '@/page/NoticeDetailPage/utils/getUserToken';
 import RejectModal from '@/features/RejectModal/RejectModal';
 import AcceptModal from '@/features/AcceptModal/AcceptModal';
 
@@ -71,8 +70,8 @@ export const ProfileTable = ({ data, pagination }: ProfileTableInterface) => {
 export const StoreTable = ({
   data,
   pagination,
-  shopId,
-  noticeId,
+  rejectedNotice,
+  acceptedNotice,
 }: StoreTableInterface) => {
   const tableData: TableInterface[] = data.map(item => ({
     id: item.id,
@@ -81,8 +80,6 @@ export const StoreTable = ({
     bio: item.bio,
     secondValue: item.phone,
   }));
-
-  const token = getUserToken();
 
   const [modalCategory, setModalCategory] = useState('');
 
@@ -112,38 +109,10 @@ export const StoreTable = ({
     setIsRejectToggle(prev => !prev);
   };
 
-  const rejectedNotice = async (newApplicationId: string) => {
-    await fetch(
-      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${newApplicationId}`,
-      {
-        method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ status: 'rejected' }),
-      },
-    );
-  };
-
   const rejectClick = () => {
     if (selectedAplicationId) {
       rejectedNotice(selectedAplicationId);
     }
-  };
-
-  const acceptedNotice = async (newApplicationId: string) => {
-    await fetch(
-      `https://bootcamp-api.codeit.kr/api/3-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${newApplicationId}`,
-      {
-        method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ status: 'accepted' }),
-      },
-    );
   };
 
   const acceptClick = () => {

--- a/src/shared/ui/Table/type.ts
+++ b/src/shared/ui/Table/type.ts
@@ -52,4 +52,6 @@ export interface StoreTableInterface {
   pagination: ReactNode;
   shopId: string;
   noticeId: string;
+  rejectedNotice: (newApplicationId: string) => Promise<void>;
+  acceptedNotice: (newApplicationId: string) => Promise<void>;
 }


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 지원 승인, 거부 공고 하나 당 딱 한 번만 되던 버그 픽스
- 지원 승인, 거부 실시간 리렌더링 구현
- 확인 눌러도 모달창 안 닫히는 버그 수정

## 📣리뷰어가 꼭 알아야 하는 사항

- 지원 목록 당 다른 id를 가져와서 로직을 적용시켜야 했는데, 모든 지원 목록을 딱 하나의 id로만 사용해서 발생한 버그였습니다.
- data를 상위 컴포넌트에서 useState로 관리하고 있었고 그걸 props로 받아왔었는데, props로 받아오지 않고 data를 State로 관리하는 컴포넌트로 직접 함수를 선언해서 함수를 props로 내려줬습니다. 그리고 data가 변경 될 때 마다 세터함수로 전달해줘서 실시간으로 리렌더링이 되게끔 해줬습니다.

## ❗관련이슈

- closed: #148 

## 🖼️스크린샷(선택)
